### PR TITLE
Simplify dependency management

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,17 +105,14 @@ uvx nox -s build
 
 ## Updating dependencies
 
-New dependencies should be added with the uv cli command `uv add
-[package-name]`. This will ensure the `uv.lock` file is updated as well.
-
-### Upgrade an existing package to latest
+Use the `uv` cli to add, update, and remove dependencies from the project.
 
 ```console
-uvx nox -s upgrade-package -- package-name
-```
+uv add [package name]
 
-### Upgrade all packages to latest
+uv remove [package name]
 
-```console
-uvx nox -s upgrade
+uv lock --upgrade
+
+uv lock --upgrade-package [package name]
 ```

--- a/noxfile.py
+++ b/noxfile.py
@@ -134,22 +134,6 @@ def validate_lock_file(session: nox.Session) -> None:
     session.run("uv", "lock")
 
 
-@nox.session(name="upgrade", python=False)
-def upgrade_dependencies(session: nox.Session) -> None:
-    """Upgrade all versions of all dependencies."""
-    session.run("uv", "lock", "--upgrade")
-
-
-@nox.session(name="upgrade-package", python=False)
-def upgrade_specific_package(session: nox.Session) -> None:
-    """Upgrade specific package name given in extra args."""
-    if not session.posargs:
-        session.log("No package name provided, nothing to do.")
-
-    else:
-        session.run("uv", "lock", "--upgrade-package", *session.posargs)
-
-
 @nox.session(name="clean", python=False)
 def clean_project_files(session: nox.Session) -> None:
     """Clean cache, .pyc, .pyo, and build artifact files from project."""


### PR DESCRIPTION
Remove the sessions for dependency management from the `noxfile.py`. Instead, lean on the `uv` cli to perform those actions. Update documentation to reflect these changes.